### PR TITLE
Client tokenEndpointAuthMethod default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flit/cdk-auth0",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A collection of AWS CDK constructs to manager your Auth0 resources programmatically",
   "keywords": [
     "aws",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -236,8 +236,7 @@ export class Client extends CustomResource {
         allowedClients: props.allowedClients || [],
         allowedLogoutUrls: props.allowedLogoutUrls || [],
         grantTypes: props.grantTypes || ["implicit", "authorization_code"],
-        tokenEndpointAuthMethod:
-          props.tokenEndpointAuthMethod || "none",
+        tokenEndpointAuthMethod: props.tokenEndpointAuthMethod || "none",
         appType: props.appType,
         isFirstParty: props.isFirstParty || false,
         oidcConformant: props.oidcConformant || false,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -102,9 +102,10 @@ export interface ClientProps extends Auth0Props {
   >;
   /**
    * Defines the requested authentication method for the token endpoint. Can be none (public client without a client secret), client_secret_post (client uses HTTP POST parameters), or client_secret_basic (client uses HTTP Basic)
-   * @defulat none
+   * @default none
    */
   readonly tokenEndpointAuthMethod?:
+    | "none"
     | "client_secret_post"
     | "client_secret_basic";
   /**
@@ -236,7 +237,7 @@ export class Client extends CustomResource {
         allowedLogoutUrls: props.allowedLogoutUrls || [],
         grantTypes: props.grantTypes || ["implicit", "authorization_code"],
         tokenEndpointAuthMethod:
-          props.tokenEndpointAuthMethod || "client_secret_basic",
+          props.tokenEndpointAuthMethod || "none",
         appType: props.appType,
         isFirstParty: props.isFirstParty || false,
         oidcConformant: props.oidcConformant || false,


### PR DESCRIPTION
Update client index.ts to allow value of 'none' to be set as the tokenEndpointAuthMethod, fixed grammar issue with JSDoc default, and set tokenEndpointAuthMethod to none in constructor as documentation indicates.  Increment patch version of project.