### PR TITLE
Add SendGrid back in as Email Provider

### DIFF
--- a/src/email-provider/handler.ts
+++ b/src/email-provider/handler.ts
@@ -35,7 +35,8 @@ export async function handler(event: CdkCustomResourceEvent) {
         };
         break;
       }
-      case "mandrill": {
+      case "mandrill":
+      case "sendgrid": {
         credentials = {
           api_key: event.ResourceProperties.credentials.apiKey,
         };

--- a/src/email-provider/index.ts
+++ b/src/email-provider/index.ts
@@ -20,14 +20,14 @@ export interface AzureProviderProps extends Auth0Props {
 /**
  * mandrill and sendgrid requires api_key
  */
-export interface MandrillCredentialsProps {
+export interface ApiKeyCredentialsProps {
   readonly apiKey: string;
 }
 
 export interface MandrillProviderProps extends Auth0Props {
   readonly name: "mandrill";
   readonly defaultFromAddress: string;
-  readonly credentials: MandrillCredentialsProps;
+  readonly credentials: ApiKeyCredentialsProps;
 }
 
 /**
@@ -59,6 +59,12 @@ export interface Microsoft365ProviderProps extends Auth0Props {
   readonly name: "ms365";
   readonly defaultFromAddress: string;
   readonly credentials: Microsoft365CredentialsProps;
+}
+
+export interface SendGridProviderProps extends Auth0Props {
+  readonly name: "sendgrid";
+  readonly defaultFromAddress: string;
+  readonly credentials: ApiKeyCredentialsProps;
 }
 
 /**
@@ -120,6 +126,7 @@ export class EmailProvider extends CustomResource {
       | MailgunProviderProps
       | Microsoft365ProviderProps
       | SesProviderProps
+      | SendGridProviderProps
       | SmtpProviderProps
       | SparkPostProviderProps,
   ) {


### PR DESCRIPTION
Added SendgridCredentialsProps for email provider back in.  Renamed MandrillCredentialsProps to APIKeyCredentialsProps for reusability between Mandrill and Sendgrid since they share the same form.  If you'd like them separate, just let me know and I can change them back.