### PR TITLE
Add email template constructs.

### DIFF
--- a/src/email-template/handler.ts
+++ b/src/email-template/handler.ts
@@ -30,30 +30,32 @@ export async function handler(event: CdkCustomResourceEvent) {
   switch (event.RequestType) {
     case "Create":
     case "Update": {
-      await auth0.emailTemplates.update({ templateName:
-        event.ResourceProperties.template },
+      await auth0.emailTemplates.update(
+        { templateName: event.ResourceProperties.template },
         {
-        template: event.ResourceProperties.template,
-        body: event.ResourceProperties.body,
-        from: event.ResourceProperties.from,
-        resultUrl: event.ResourceProperties.resultUrl,
-        subject: event.ResourceProperties.subject,
-        syntax: event.ResourceProperties.syntax,
-        urlLifetimeInSeconds:
-          Number(event.ResourceProperties.urlLifetimeInSeconds),
-        includeEmailInRedirect:
-          event.ResourceProperties.includeEmailInRedirect === "true",
-        enabled: event.ResourceProperties.enabled === "true",
-      });
+          template: event.ResourceProperties.template,
+          body: event.ResourceProperties.body,
+          from: event.ResourceProperties.from,
+          resultUrl: event.ResourceProperties.resultUrl,
+          subject: event.ResourceProperties.subject,
+          syntax: event.ResourceProperties.syntax,
+          urlLifetimeInSeconds: Number(
+            event.ResourceProperties.urlLifetimeInSeconds,
+          ),
+          includeEmailInRedirect:
+            event.ResourceProperties.includeEmailInRedirect === "true",
+          enabled: event.ResourceProperties.enabled === "true",
+        },
+      );
 
       return {
         PhysicalResource: event.ResourceProperties.template,
-      }
+      };
     }
     case "Delete": {
       return {
         PhysicalResource: event.ResourceProperties.PhysicalResourceId,
-      }
+      };
     }
     default: {
       throw new Error("Invalid request type");

--- a/src/email-template/handler.ts
+++ b/src/email-template/handler.ts
@@ -1,0 +1,62 @@
+import type { CdkCustomResourceEvent } from "aws-lambda";
+import { ManagementClient } from "auth0";
+
+import type { ENV } from "./../lambda-base";
+import { getSecretValue } from "./../get-secret-value";
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends ENV {}
+  }
+}
+
+export async function handler(event: CdkCustomResourceEvent) {
+  const auth0Api = JSON.parse(
+    await getSecretValue(
+      event.ResourceProperties.secretName,
+      process.env.PARAMETERS_SECRETS_EXTENSION_HTTP_PORT,
+      process.env.AWS_SESSION_TOKEN,
+    ),
+  );
+
+  const auth0 = new ManagementClient({
+    domain: auth0Api.domain,
+    clientId: auth0Api.clientId,
+    clientSecret: auth0Api.clientSecret,
+  });
+
+  console.log(`Event: ${JSON.stringify(event)}`);
+
+  switch (event.RequestType) {
+    case "Create":
+    case "Update": {
+      await auth0.emailTemplates.update({ templateName:
+        event.ResourceProperties.template },
+        {
+        template: event.ResourceProperties.template,
+        body: event.ResourceProperties.body,
+        from: event.ResourceProperties.from,
+        resultUrl: event.ResourceProperties.resultUrl,
+        subject: event.ResourceProperties.subject,
+        syntax: event.ResourceProperties.syntax,
+        urlLifetimeInSeconds:
+          Number(event.ResourceProperties.urlLifetimeInSeconds),
+        includeEmailInRedirect:
+          event.ResourceProperties.includeEmailInRedirect === "true",
+        enabled: event.ResourceProperties.enabled === "true",
+      });
+
+      return {
+        PhysicalResource: event.ResourceProperties.template,
+      }
+    }
+    case "Delete": {
+      return {
+        PhysicalResource: event.ResourceProperties.PhysicalResourceId,
+      }
+    }
+    default: {
+      throw new Error("Invalid request type");
+    }
+  }
+}

--- a/src/email-template/index.ts
+++ b/src/email-template/index.ts
@@ -1,0 +1,84 @@
+import { CustomResource } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { Auth0Props } from "../auth0-props";
+import { Provider } from "./provider";
+
+export interface EmailTemplateProps extends Auth0Props{
+  /**
+   * Template name. Can be verify_email, verify_email_by_code, reset_email, reset_email_by_code, welcome_email,
+   * blocked_account, stolen_credentials, enrollment_email, mfa_oob_code, user_invitation, change_password (legacy),
+   * or password_reset (legacy).
+   */
+  readonly template:
+    | "verify_email"
+    | "verify_email_by_code"
+    | "reset_email"
+    | "reset_email_by_code"
+    | "welcome_email"
+    | "blocked_account"
+    | "stolen_credentials"
+    | "enrollment_email"
+    | "mfa_oob_code"
+    | "user_invitation"
+    | "change_password";
+  /**
+   * Body of the email template.
+   */
+  readonly body: string;
+  /**
+   * Senders from email address.
+   */
+  readonly from: string;
+  /**
+   * URL to redirect the user to after a successful action.
+   */
+  readonly resultUrl?: string;
+  /**
+   * Subject line of the email.
+   */
+  readonly subject: string;
+  /**
+   * Syntax of the template body.
+   * @default liquid
+   */
+  readonly syntax?: string;
+  /**
+   * Lifetime in seconds that the link within the email will be valid for.
+   * @default 432000 (5 days)
+   */
+  readonly urlLifetimeInSeconds?: number;
+  /**
+   * Whether the reset_email and verify_email templates should include the user's email address as the email parameter
+   * in the returnUrl (true) or whether no email address should be included in the redirect (false). Defaults to true.
+   * @default true
+   */
+  readonly includeEmailInRedirect?: boolean;
+  /**
+   * Whether the template is enabled (true) or disabled (false).
+   */
+  readonly enabled: boolean;
+}
+
+/**
+ * @category Constructs
+ */
+export class EmailTemplate extends CustomResource {
+  constructor(scope: Construct, id: string, props: EmailTemplateProps) {
+    super(scope, id, {
+      resourceType: "Custom::Auth0Action",
+      serviceToken: Provider.getOrCreate(scope, props.apiSecret),
+      properties: {
+        secretName: props.apiSecret.secretName,
+        template: props.template,
+        body: props.body,
+        from: props.from,
+        resultUrl: props.resultUrl,
+        subject: props.subject,
+        syntax: props.syntax || 'liquid',
+        urlLifetimeInSeconds: props?.urlLifetimeInSeconds || 432000,
+        includeEmailInRedirect: props?.includeEmailInRedirect || true,
+        enabled: props.enabled,
+      }
+    });
+  }
+}

--- a/src/email-template/index.ts
+++ b/src/email-template/index.ts
@@ -3,7 +3,7 @@ import { Construct } from "constructs";
 import { Auth0Props } from "../auth0-props";
 import { Provider } from "./provider";
 
-export interface EmailTemplateProps extends Auth0Props{
+export interface EmailTemplateProps extends Auth0Props {
   /**
    * Template name. Can be verify_email, verify_email_by_code, reset_email, reset_email_by_code, welcome_email,
    * blocked_account, stolen_credentials, enrollment_email, mfa_oob_code, user_invitation, change_password (legacy),
@@ -74,11 +74,11 @@ export class EmailTemplate extends CustomResource {
         from: props.from,
         resultUrl: props.resultUrl,
         subject: props.subject,
-        syntax: props.syntax || 'liquid',
+        syntax: props.syntax || "liquid",
         urlLifetimeInSeconds: props?.urlLifetimeInSeconds || 432000,
         includeEmailInRedirect: props?.includeEmailInRedirect || true,
         enabled: props.enabled,
-      }
+      },
     });
   }
 }

--- a/src/email-template/provider.ts
+++ b/src/email-template/provider.ts
@@ -1,0 +1,28 @@
+import { Provider as AwsProvider } from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
+import { LambdaBase, LambdaRole } from "../lambda-base";
+import { join } from "path";
+import { Stack } from "aws-cdk-lib";
+import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+
+export class Provider extends AwsProvider {
+  constructor(scope: Construct, id: string) {
+    super(scope, id, {
+      onEventHandler: new LambdaBase(scope, `${id}OnEventHandler`, {
+        entry: join(__dirname, "./../../src/email-template/handler.ts"),
+      }),
+      role: new LambdaRole(scope, `${id}Role`),
+    });
+  }
+
+  static getOrCreate(scope: Construct, apiSecret: ISecret) {
+    const stack = Stack.of(scope);
+    const id = "Auth0EmailTemplateProvider";
+    const provider =
+      (stack.node.tryFindChild(id) as Provider) || new Provider(stack, id);
+
+    apiSecret.grantRead(provider.onEventHandler);
+
+    return provider.serviceToken;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./client-grant";
 export * from "./connection";
 export * from "./custom-domain";
 export * from "./email-provider";
+export * from "./email-template";
 export * from "./organization";
 export * from "./prompt-settings";
 export * from "./resource-server";


### PR DESCRIPTION
The email-template/handler uses the auth0.emailTemplates.update() API as all possible templates are created when the tenant is provisioned.  Default the syntax field to 'liquid' as that is the only possible value permitted at this time.