### PR TITLE
Update email template create scenarios

### DIFF
--- a/src/email-template/handler.ts
+++ b/src/email-template/handler.ts
@@ -29,15 +29,16 @@ export async function handler(event: CdkCustomResourceEvent) {
 
   switch (event.RequestType) {
     case "Create": {
-      const body  = {
+      const body = {
         template: event.ResourceProperties.template,
         body: event.ResourceProperties.body,
         from: event.ResourceProperties.from,
         resultUrl: event.ResourceProperties.resultUrl,
         subject: event.ResourceProperties.subject,
         syntax: event.ResourceProperties.syntax,
-        urlLifetimeInSeconds:
-          Number(event.ResourceProperties.urlLifetimeInSeconds),
+        urlLifetimeInSeconds: Number(
+          event.ResourceProperties.urlLifetimeInSeconds,
+        ),
         includeEmailInRedirect:
           event.ResourceProperties.includeEmailInRedirect === "true",
         enabled: event.ResourceProperties.enabled === "true",
@@ -46,10 +47,13 @@ export async function handler(event: CdkCustomResourceEvent) {
       try {
         await auth0.emailTemplates.create(body);
       } catch (error: any) {
-        if(error.statusCode === 409) {
-          console.info(`${event.ResourceProperties.template} already created, updating email template.`);
-          await auth0.emailTemplates.update({ templateName:
-            event.ResourceProperties.template}, body
+        if (error.statusCode === 409) {
+          console.info(
+            `${event.ResourceProperties.template} already created, updating email template.`,
+          );
+          await auth0.emailTemplates.update(
+            { templateName: event.ResourceProperties.template },
+            body,
           );
         } else {
           console.error(JSON.stringify(error));
@@ -59,28 +63,30 @@ export async function handler(event: CdkCustomResourceEvent) {
 
       return {
         PhysicalResource: event.ResourceProperties.template,
-      }
+      };
     }
     case "Update": {
-      await auth0.emailTemplates.update({ templateName:
-          event.ResourceProperties.template}, {
+      await auth0.emailTemplates.update(
+        { templateName: event.ResourceProperties.template },
+        {
           template: event.ResourceProperties.template,
           body: event.ResourceProperties.body,
           from: event.ResourceProperties.from,
           resultUrl: event.ResourceProperties.resultUrl,
           subject: event.ResourceProperties.subject,
           syntax: event.ResourceProperties.syntax,
-          urlLifetimeInSeconds:
-            Number(event.ResourceProperties.urlLifetimeInSeconds),
+          urlLifetimeInSeconds: Number(
+            event.ResourceProperties.urlLifetimeInSeconds,
+          ),
           includeEmailInRedirect:
             event.ResourceProperties.includeEmailInRedirect === "true",
           enabled: event.ResourceProperties.enabled === "true",
-        }
+        },
       );
 
       return {
         PhysicalResource: event.ResourceProperties.template,
-      }
+      };
     }
     case "Delete": {
       return {


### PR DESCRIPTION
Ran into a scenario in our upper environments that requires this change.

Auth0 does not allow you to delete an email template leading to scenarios where if a specific email template has been touched in the UI, you cannot create it again.  Auth0 UI does have a reset button to reset the template to it's original state, but it does not allow you to create it again, only to update it even if it has been reset.

In such cases, this will now try to create the template, if it receives a 409, it will try to update the template.  This would be much more easily solved if the Auth0 API had delete functionality for the email templates.