### PR TITLE
fix: Fix breaking changes in auth0 v5 sdk

### DIFF
--- a/src/action/handler.ts
+++ b/src/action/handler.ts
@@ -40,13 +40,13 @@ export async function handler(event: CdkCustomResourceEvent) {
 					runtime: event.ResourceProperties.runtime,
 					secrets: event.ResourceProperties.secrets,
 				})
-			).data.id;
+			).id;
 
-			while ((await auth0.actions.get({ id: id })).data.status !== "built") {
+			while ((await auth0.actions.get(id)).status !== "built") {
 				await timeout(5000);
 			}
 
-			await auth0.actions.deploy({ id: id });
+			await auth0.actions.deploy(id);
 
 			return {
 				PhysicalResourceId: id,
@@ -57,7 +57,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 		}
 		case "Update": {
 			await auth0.actions.update(
-				{ id: event.PhysicalResourceId },
+				event.PhysicalResourceId,
 				{
 					name: event.ResourceProperties.name,
 					code: event.ResourceProperties.code,
@@ -69,13 +69,13 @@ export async function handler(event: CdkCustomResourceEvent) {
 			);
 
 			while (
-				(await auth0.actions.get({ id: event.PhysicalResourceId })).data
+				(await auth0.actions.get(event.PhysicalResourceId))
 					.status !== "built"
 			) {
 				await timeout(5000);
 			}
 
-			await auth0.actions.deploy({ id: event.PhysicalResourceId });
+			await auth0.actions.deploy(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,
@@ -85,7 +85,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.actions.delete({ id: event.PhysicalResourceId, force: true });
+			await auth0.actions.delete(event.PhysicalResourceId, { force: true });
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/branding-settings/handler.ts
+++ b/src/branding-settings/handler.ts
@@ -27,7 +27,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 	switch (event.RequestType) {
 		case "Create": {
-			await auth0.branding.updateSettings({
+			await auth0.branding.update({
 				logo_url: event.ResourceProperties.logoUrl,
 				favicon_url: event.ResourceProperties.faviconUrl,
 				colors: event.ResourceProperties.colors,
@@ -41,7 +41,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Update": {
-			await auth0.branding.updateSettings({
+			await auth0.branding.update({
 				logo_url: event.ResourceProperties.logoUrl,
 				favicon_url: event.ResourceProperties.faviconUrl,
 				colors: event.ResourceProperties.colors,

--- a/src/branding-theme/handler.ts
+++ b/src/branding-theme/handler.ts
@@ -28,7 +28,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 	switch (event.RequestType) {
 		case "Create": {
 			const id = (
-				await auth0.branding.createTheme({
+				await auth0.branding.themes.create({
 					displayName: event.ResourceProperties.displayName,
 					colors: {
 						base_focus_color: event.ResourceProperties.colors.baseFocusColor,
@@ -127,7 +127,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 						page_layout: event.ResourceProperties.pageBackground.pageLayout,
 					},
 				})
-			).data.themeId;
+			).themeId;
 
 			return {
 				PhysicalResourceId: id,
@@ -137,8 +137,8 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Update": {
-			await auth0.branding.updateTheme(
-				{ themeId: event.PhysicalResourceId },
+			await auth0.branding.themes.update(
+				event.PhysicalResourceId,
 				{
 					displayName: event.ResourceProperties.displayName,
 					colors: {
@@ -248,7 +248,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.branding.deleteTheme({ themeId: event.PhysicalResourceId });
+			await auth0.branding.themes.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/client-grant/handler.ts
+++ b/src/client-grant/handler.ts
@@ -35,7 +35,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 						`https://${auth0Api.domain}/api/v2/`,
 					scope: event.ResourceProperties.scope,
 				})
-			).data.id;
+			).id;
 
 			return {
 				PhysicalResourceId: id,
@@ -60,7 +60,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			}
 
 			await auth0.clientGrants.update(
-				{ id: event.PhysicalResourceId },
+				event.PhysicalResourceId,
 				{
 					scope: event.ResourceProperties.scope,
 				},
@@ -74,9 +74,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.clientGrants.delete({
-				id: event.PhysicalResourceId,
-			});
+			await auth0.clientGrants.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/client/handler.ts
+++ b/src/client/handler.ts
@@ -96,7 +96,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 					organization_require_behavior:
 						event.ResourceProperties.organizationRequireBehavior,
 				})
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: client.client_id,
@@ -116,7 +116,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 		}
 		case "Update": {
 			await auth0.clients.update(
-				{ client_id: event.PhysicalResourceId },
+				event.PhysicalResourceId,
 				{
 					name: event.ResourceProperties.name || event.LogicalResourceId,
 					description: event.ResourceProperties.description,
@@ -180,8 +180,8 @@ export async function handler(event: CdkCustomResourceEvent) {
 			);
 
 			const client = (
-				await auth0.clients.get({ client_id: event.PhysicalResourceId })
-			).data;
+				await auth0.clients.get(event.PhysicalResourceId)
+			);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,
@@ -200,7 +200,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.clients.delete({ client_id: event.PhysicalResourceId });
+			await auth0.clients.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/connection/handler.ts
+++ b/src/connection/handler.ts
@@ -30,7 +30,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			const connection = (
 				event.ResourceProperties.connectionId
 					? await auth0.connections.update(
-							{ id: event.ResourceProperties.connectionId },
+							event.ResourceProperties.connectionId,
 							{
 								display_name: event.ResourceProperties.displayName,
 								enabled_clients: event.ResourceProperties.enabledClients,
@@ -54,7 +54,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 									event.ResourceProperties.disableSignup === "true",
 							},
 					  })
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: connection.id,
@@ -78,7 +78,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 			const connection = (
 				await auth0.connections.update(
-					{ id: event.PhysicalResourceId },
+					event.PhysicalResourceId,
 					{
 						display_name: event.ResourceProperties.displayName,
 						enabled_clients: event.ResourceProperties.enabledClients,
@@ -89,7 +89,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 						},
 					},
 				)
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,
@@ -101,9 +101,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 		}
 		case "Delete": {
 			if (event.ResourceProperties.deletionProtection !== "true") {
-				await auth0.connections.delete({
-					id: event.PhysicalResourceId,
-				});
+				await auth0.connections.delete(event.PhysicalResourceId);
 			}
 
 			return {

--- a/src/custom-domain/handler.ts
+++ b/src/custom-domain/handler.ts
@@ -36,7 +36,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 					custom_client_ip_header:
 						event.ResourceProperties.customClientIpHeader,
 				})
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: customDomain.custom_domain_id,
@@ -50,14 +50,14 @@ export async function handler(event: CdkCustomResourceEvent) {
 		case "Update": {
 			const customDomain = (
 				await auth0.customDomains.update(
-					{ id: event.PhysicalResourceId },
+					event.PhysicalResourceId,
 					{
 						tls_policy: event.ResourceProperties.tlsPolicy,
 						custom_client_ip_header:
 							event.ResourceProperties.customClientIpHeader,
 					},
 				)
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,
@@ -69,7 +69,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.customDomains.delete({ id: event.PhysicalResourceId });
+			await auth0.customDomains.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/email-provider/handler.ts
+++ b/src/email-provider/handler.ts
@@ -89,15 +89,15 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 	switch (event.RequestType) {
 		case "Create": {
-			if (((await auth0.emails.get()).data.name?.trim()?.length || 0) > 0) {
-				await auth0.emails.update({
+			if (((await auth0.emails.provider.get()).name?.trim()?.length || 0) > 0) {
+				await auth0.emails.provider.update({
 					name: event.ResourceProperties.name,
 					enabled: true,
 					default_from_address: event.ResourceProperties.defaultFromAddress,
 					credentials: credentials,
 				});
 			} else {
-				await auth0.emails.configure({
+				await auth0.emails.provider.create({
 					name: event.ResourceProperties.name,
 					enabled: true,
 					default_from_address: event.ResourceProperties.defaultFromAddress,
@@ -108,7 +108,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			return;
 		}
 		case "Update": {
-			await auth0.emails.update({
+			await auth0.emails.provider.update({
 				name: event.ResourceProperties.name,
 				enabled: true,
 				default_from_address: event.ResourceProperties.defaultFromAddress,
@@ -118,7 +118,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			return;
 		}
 		case "Delete": {
-			await auth0.emails.update({
+			await auth0.emails.provider.update({
 				enabled: false,
 			});
 

--- a/src/email-template/handler.ts
+++ b/src/email-template/handler.ts
@@ -52,7 +52,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 						`${event.ResourceProperties.template} already created, updating email template.`,
 					);
 					await auth0.emailTemplates.update(
-						{ templateName: event.ResourceProperties.template },
+						event.ResourceProperties.template,
 						body,
 					);
 				} else {
@@ -67,7 +67,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 		}
 		case "Update": {
 			await auth0.emailTemplates.update(
-				{ templateName: event.ResourceProperties.template },
+				event.ResourceProperties.template,
 				{
 					template: event.ResourceProperties.template,
 					body: event.ResourceProperties.body,

--- a/src/organization/handler.ts
+++ b/src/organization/handler.ts
@@ -56,7 +56,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 						  ]
 						: [],
 				})
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: organization.id,
@@ -75,7 +75,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 			const organization = (
 				await auth0.organizations.update(
-					{ id: event.PhysicalResourceId },
+					event.PhysicalResourceId,
 					{
 						name: event.ResourceProperties.name,
 						display_name: event.ResourceProperties.displayName,
@@ -92,7 +92,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 						metadata: event.ResourceProperties.metadata || [],
 					},
 				)
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: organization.id,
@@ -102,7 +102,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.organizations.delete({ id: event.PhysicalResourceId });
+			await auth0.organizations.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/prompt-settings/handler.ts
+++ b/src/prompt-settings/handler.ts
@@ -27,7 +27,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 	switch (event.RequestType) {
 		case "Create": {
-			await auth0.prompts.update({
+			await auth0.prompts.updateSettings({
 				universal_login_experience:
 					event.ResourceProperties.universalLoginExperience,
 				identifier_first: event.ResourceProperties.identifierFirst === "true",
@@ -40,7 +40,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Update": {
-			await auth0.prompts.update({
+			await auth0.prompts.updateSettings({
 				universal_login_experience:
 					event.ResourceProperties.universalLoginExperience,
 				identifier_first: event.ResourceProperties.identifierFirst === "true",

--- a/src/resource-server/handler.ts
+++ b/src/resource-server/handler.ts
@@ -43,7 +43,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 							.skipConsentForVerifiableFirstPartyClients === "true",
 					enforce_policies: event.ResourceProperties.enforcePolicies === "true",
 				})
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: resourceServers.id,
@@ -56,7 +56,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 		case "Update": {
 			const resourceServers = (
 				await auth0.resourceServers.update(
-					{ id: event.PhysicalResourceId },
+					event.PhysicalResourceId,
 					{
 						name: event.ResourceProperties.name || event.LogicalResourceId,
 						scopes: event.ResourceProperties.scopes,
@@ -73,7 +73,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 							event.ResourceProperties.enforcePolicies === "true",
 					},
 				)
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,
@@ -84,9 +84,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.resourceServers.delete({
-				id: event.PhysicalResourceId,
-			});
+			await auth0.resourceServers.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/role/handler.ts
+++ b/src/role/handler.ts
@@ -29,7 +29,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			const role = (
 				event.ResourceProperties.roleId
 					? await auth0.roles.update(
-							{ id: event.ResourceProperties.roleId },
+							event.ResourceProperties.roleId,
 							{
 								name: event.ResourceProperties.name,
 								description: event.ResourceProperties.description,
@@ -39,7 +39,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 							name: event.ResourceProperties.name,
 							description: event.ResourceProperties.description,
 					  })
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: role.id,
@@ -51,13 +51,13 @@ export async function handler(event: CdkCustomResourceEvent) {
 		case "Update": {
 			const role = (
 				await auth0.roles.update(
-					{ id: event.PhysicalResourceId },
+					event.PhysicalResourceId,
 					{
 						name: event.ResourceProperties.name,
 						description: event.ResourceProperties.description,
 					},
 				)
-			).data;
+			);
 
 			return {
 				PhysicalResourceId: role.id,
@@ -68,7 +68,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Delete": {
-			await auth0.roles.delete({ id: event.PhysicalResourceId });
+			await auth0.roles.delete(event.PhysicalResourceId);
 
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,

--- a/src/tenant-settings/handler.ts
+++ b/src/tenant-settings/handler.ts
@@ -27,7 +27,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 	switch (event.RequestType) {
 		case "Create": {
-			await auth0.tenants.updateSettings({
+			await auth0.tenants.settings.update({
 				change_password: {
 					enabled: event.ResourceProperties.changePassword.enabled === "true",
 					html: event.ResourceProperties.changePassword.html,
@@ -57,9 +57,6 @@ export async function handler(event: CdkCustomResourceEvent) {
 						event.ResourceProperties.flags.enablePipeline2 === "true",
 					enable_dynamic_client_registration:
 						event.ResourceProperties.flags.enableDynamicClientRegistration ===
-						"true",
-					enable_custom_domain_in_emails:
-						event.ResourceProperties.flags.enableCustomDomainInEmails ===
 						"true",
 					enable_legacy_profile:
 						event.ResourceProperties.flags.enableLegacyProfile === "true",
@@ -111,7 +108,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			};
 		}
 		case "Update": {
-			await auth0.tenants.updateSettings({
+			await auth0.tenants.settings.update({
 				change_password: {
 					enabled: event.ResourceProperties.changePassword.enabled === "true",
 					html: event.ResourceProperties.changePassword.html,
@@ -139,12 +136,6 @@ export async function handler(event: CdkCustomResourceEvent) {
 						event.ResourceProperties.flags.enableApisSection === "true",
 					enable_pipeline2:
 						event.ResourceProperties.flags.enablePipeline2 === "true",
-					enable_dynamic_client_registration:
-						event.ResourceProperties.flags.enableDynamicClientRegistration ===
-						"true",
-					enable_custom_domain_in_emails:
-						event.ResourceProperties.flags.enableCustomDomainInEmails ===
-						"true",
 					enable_legacy_profile:
 						event.ResourceProperties.flags.enableLegacyProfile === "true",
 					disable_clickjack_protection_headers:

--- a/src/trigger/handler.ts
+++ b/src/trigger/handler.ts
@@ -27,8 +27,8 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 	switch (event.RequestType) {
 		case "Create": {
-			await auth0.actions.updateTriggerBindings(
-				{ triggerId: event.ResourceProperties.id },
+			await auth0.actions.triggers.bindings.updateMany(
+				event.ResourceProperties.id,
 				{
 					bindings: event.ResourceProperties.actions.map((action: string) => {
 						return { ref: { type: "action_id", value: action } };
@@ -39,8 +39,8 @@ export async function handler(event: CdkCustomResourceEvent) {
 			return;
 		}
 		case "Update": {
-			await auth0.actions.updateTriggerBindings(
-				{ triggerId: event.ResourceProperties.id },
+			await auth0.actions.triggers.bindings.updateMany(
+				event.ResourceProperties.id,
 				{
 					bindings: event.ResourceProperties.actions.map((action: string) => {
 						return { ref: { type: "action_id", value: action } };


### PR DESCRIPTION
Our cloud formation deploys started failing and after debugging we found that the lambdas were creating bad urls such as `xxx.auth0.com/api/v2/resource-servers/%5Bobject%20Object%5D` when attempting to manage resources. It looks like the v5 auth0 management sdk has breaking changes that need to be resolved.