### PR TITLE
feature: Allow passing a string as the audience for client_grant.

### DIFF
--- a/src/client-grant/handler.ts
+++ b/src/client-grant/handler.ts
@@ -40,7 +40,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			return {
 				PhysicalResourceId: id,
 				Data: {
-					clinetGrantId: id,
+					clientGrantId: id,
 				},
 			};
 		}
@@ -66,7 +66,7 @@ export async function handler(event: CdkCustomResourceEvent) {
 			return {
 				PhysicalResourceId: event.PhysicalResourceId,
 				Data: {
-					clinetGrantId: event.PhysicalResourceId,
+					clientGrantId: event.PhysicalResourceId,
 				},
 			};
 		}

--- a/src/client-grant/index.ts
+++ b/src/client-grant/index.ts
@@ -8,7 +8,7 @@ import { ResourceServer } from "./../resource-server";
 
 export interface ClientGrantProps extends Auth0Props {
 	readonly client: Client;
-	readonly audience?: ResourceServer;
+	readonly audience?: ResourceServer | string;
 	readonly scope: Array<string>;
 }
 
@@ -25,7 +25,10 @@ export class ClientGrant extends CustomResource {
 			properties: {
 				secretName: props.apiSecret.secretName,
 				clinetId: props.client.clientId,
-				audience: props.audience?.resourceServerIdentifier,
+				audience:
+					typeof props.audience === "string"
+						? props.audience
+						: props.audience?.resourceServerIdentifier,
 				scope: props.scope,
 			},
 		});

--- a/src/client-grant/index.ts
+++ b/src/client-grant/index.ts
@@ -16,7 +16,7 @@ export interface ClientGrantProps extends Auth0Props {
  * @category Constructs
  */
 export class ClientGrant extends CustomResource {
-	public readonly actionId = this.getAttString("clinetGrantId");
+	public readonly actionId = this.getAttString("clientGrantId");
 
 	constructor(scope: Construct, id: string, props: ClientGrantProps) {
 		super(scope, id, {


### PR DESCRIPTION
Client Grant Audience
----

`ClientGrant` currently requires a `ResourceServer` construct to be passed as its audience, from which it grabs the identifier. This makes it impossible to create a `ClientGrant` for the tenant's Auth0 management API.

This change allows passing either a `ResourceServer` or a string as the audience.

Typo
----
I also spotted a typo which I fixed while passing through. 

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/cc90d0bc-6597-4aea-bc2d-0a1190a0eb8c" />
