### PR TITLE
fix: Fixes an issue where creating an email provider when none existed was failing

### DIFF
--- a/src/email-provider/handler.ts
+++ b/src/email-provider/handler.ts
@@ -89,7 +89,17 @@ export async function handler(event: CdkCustomResourceEvent) {
 
 	switch (event.RequestType) {
 		case "Create": {
-			if (((await auth0.emails.provider.get()).name?.trim()?.length || 0) > 0) {
+			let isEmailProviderConfigured = false;
+
+			try {
+				isEmailProviderConfigured =
+					((await auth0.emails.provider.get()).name?.trim()?.length || 0) > 0;
+			} catch {
+				// The get throws with a 404 when no provider is configured
+				// do nothing, isEmailProviderConfigured is already false
+			}
+
+			if (isEmailProviderConfigured) {
 				await auth0.emails.provider.update({
 					name: event.ResourceProperties.name,
 					enabled: true,


### PR DESCRIPTION
Email provider Create
----
Trying to create an EmailProvider in an Auth0 tenant with none already configured was failing with a 404 error.

From their API documentation: https://auth0.com/docs/api/management/v2/emails/get-provider

> 404 Email provider has not been configured.

This pull request changes the create behaviour to make the `emails.provider.get()` safe and keeping the same behaviour where if one already exists it is updated else created.